### PR TITLE
For IRremoteESP8266 v2.5.0 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ Access-Control-Allow-Origin: *
 
 * [Arduino core for ESP8266 WiFi chip](https://github.com/esp8266/Arduino) <= **2.3.0**
 * [aJson](https://github.com/interactive-matter/aJson) == v1.5
-* [IRremoteESP8266](https://github.com/markszabo/IRremoteESP8266) >= v2.4.2
+* [IRremoteESP8266](https://github.com/markszabo/IRremoteESP8266) >= v2.5.0

--- a/minirum/minirum.ino
+++ b/minirum/minirum.ino
@@ -11,7 +11,7 @@
 
 #define SEND_PIN 12
 #define RECV_PIN 14
-#define TIMEOUT MAX_TIMEOUT_MS
+#define TIMEOUT kMaxTimeoutMs
 #define CAPTURE_BUFFER_SIZE 1024
 
 char* localName = "minirum-";


### PR DESCRIPTION
To follow variable naming rule changes on IRremoteESP8266 v2.5.0.